### PR TITLE
Config Export/Import via url schemes

### DIFF
--- a/FBTweak/FBTweakStore.h
+++ b/FBTweak/FBTweakStore.h
@@ -46,6 +46,13 @@
 - (void)removeTweakCategory:(FBTweakCategory *)category;
 
 /**
+ @abstract Loads Tweak parameters from a URL Scheme.
+ @param url The url containing the GET parameters and values.
+ */
+- (void)loadTweakValuesFromURL:(NSURL *)url;
+
+
+/**
   @abstract Resets all tweaks in the store.
  */
 - (void)reset;

--- a/FBTweak/FBTweakStore.m
+++ b/FBTweak/FBTweakStore.m
@@ -61,6 +61,32 @@
   [_orderedCategories removeObject:category];
 }
 
+-(void)loadTweakValuesFromURL:(NSURL *)url
+{
+    if (![[url host] isEqualToString:@"importTweaks"]) {
+        return;
+    }
+    [self reset];
+    NSNumberFormatter* nf=[[NSNumberFormatter alloc] init];
+    NSArray* parameters=[[[url query] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding] componentsSeparatedByString:@"&"];
+    for (NSString* param in parameters) {
+        NSArray* paramComponents=[param componentsSeparatedByString:@"="];
+        NSArray* tweakPath=[paramComponents[0] componentsSeparatedByString:@"-"];
+        
+        FBTweakCategory* category=(FBTweakCategory*)[self tweakCategoryWithName:tweakPath[0]];
+        FBTweakCollection* collection=(FBTweakCollection*)[category tweakCollectionWithName:tweakPath[1]];
+        FBTweak* tweak= (FBTweak*)[collection tweakWithIdentifier:[NSString
+                                                                   stringWithFormat:@"FBTweak:%@",paramComponents[0]]] ;
+        NSNumber* tweakValue=[nf numberFromString:paramComponents[1]];
+        if (!tweakValue) {
+            tweak.currentValue=paramComponents[1];
+        }
+        else{
+            tweak.currentValue=tweakValue;
+        }
+    }
+}
+
 - (void)reset
 {
   for (FBTweakCategory *category in self.tweakCategories) {

--- a/FBTweakExample/FBAppDelegate.m
+++ b/FBTweakExample/FBAppDelegate.m
@@ -11,7 +11,7 @@
 #import <FBTweak/FBTweakShakeWindow.h>
 #import <FBTweak/FBTweakInline.h>
 #import <FBTweak/FBTweakViewController.h>
-
+#import <FBTweak/FBTweakStore.h>
 #import "FBAppDelegate.h"
 
 @interface FBAppDelegate () <FBTweakObserver, FBTweakViewControllerDelegate>
@@ -24,6 +24,7 @@
   UILabel *_label;
   FBTweak *_flipTweak;
 }
+
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
@@ -65,6 +66,13 @@
   [_rootViewController.view addSubview:tweaksButton];
   
   return YES;
+}
+
+- (BOOL)application:(UIApplication *)application handleOpenURL:(NSURL *)url
+{
+    [[FBTweakStore sharedInstance] loadTweakValuesFromURL:url];
+    
+    return YES;
 }
 
 - (void)tweakDidChange:(FBTweak *)tweak

--- a/FBTweakExample/FBTweakExample-Info.plist
+++ b/FBTweakExample/FBTweakExample-Info.plist
@@ -20,6 +20,17 @@
 	<string>1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>FBTweaks.com.facebook.FBTweakExample</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ As with `FBTweakValue`, in release builds `FBTweakBind` expands to just setting 
 ### Tweaks UI
 To configure your tweaks, you need a way to show the configuration UI. There's two options for that:
 
- - Traditionally, tweaks is activated by shaking your phone. To use that, just replace your root `UIWindow` with a `FBTweakShakeWindow`. 
+ - Traditionally, tweaks is activated by shaking your phone. To use that, just replace your root `UIWindow` with a `FBTweakShakeWindow`.
  - You can present a `FBTweakViewController` from anywhere in your app. Be sure to restrict the activation UI to debug builds!
 
 ### Advanced
@@ -89,6 +89,21 @@ Then, you can watch for when the tweak changes:
 
 To override when tweaks are enabled, you can define the `FB_TWEAK_ENABLED` macro. It's suggested to avoid including them when submitting to the App Store.
 
+To enable URL Scheme config sharing, register the following URL Scheme in your info.plist
+
+FBTweaks.(Your Bundle Identifier)
+
+and add the following code in your AppDelegate
+
+```objective-c
+- (BOOL)application:(UIApplication *)application handleOpenURL:(NSURL *)url
+{
+    [[FBTweakStore sharedInstance] loadTweakValuesFromURL:url];
+
+    return YES;
+}
+```
+
 ### How it works
 In debug builds, the tweak macros use `__attribute__((section))` to statically store data about each tweak in the `__FBTweak` section of the mach-o. Tweaks loads that data at startup and loads the latest values from `NSUserDefaults`.
 
@@ -109,4 +124,3 @@ See the CONTRIBUTING file for how to help out.
 
 ## License
 Tweaks is BSD-licensed. We also provide an additional patent grant.
-

--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ To override when tweaks are enabled, you can define the `FB_TWEAK_ENABLED` macro
 
 To enable URL Scheme config sharing, register the following URL Scheme in your info.plist
 
+```
 FBTweaks.(Your Bundle Identifier)
+```
 
 and add the following code in your AppDelegate
 


### PR DESCRIPTION
Quick and easy sharing via a url scheme. Much more convenient than other methods as all it requires is a paste, send and tap to export and import. Heres a sample URL scheme based config for the example project. 

FBTweaks.com.facebook.FBTweakExample://importFBTweaks?Window-Color-Red=0.9800000000000001&Window-Color-Green=0.7999999999999999&Window-Color-Blue=0.9400000000000001&Window-Effects-Upside%20Down=1&Content-Text-Size=36.24000000000001&Content-Text-String=Test&Content-Text-Alpha=0.6600000000000001&Content-Animation-Duration=0.401&Content-Animation-Scale=2.792


There will be an issue if there is a '-' in the name of the category, collection or tweak. Is there a simpler way to work around this?

This is my first open source contribution and I hope you think this is useful!