### PR TITLE
Enabled tweak view controller presentation anywhere in hierarchy.

### DIFF
--- a/FBTweak/FBTweakShakeWindow.m
+++ b/FBTweak/FBTweakShakeWindow.m
@@ -25,14 +25,17 @@ static CFTimeInterval _FBTweakShakeWindowMinTimeInterval = 0.4;
 
 - (void)_presentTweaks
 {
-  UIViewController *rootViewController = self.rootViewController;
+  UIViewController *visibleViewController = self.rootViewController;
+  while (visibleViewController.presentedViewController != nil) {
+    visibleViewController = visibleViewController.presentedViewController;
+  }
   
   // Prevent double-presenting the tweaks view controller.
-  if (![rootViewController.presentedViewController isKindOfClass:[FBTweakViewController class]]) {
+  if (![visibleViewController isKindOfClass:[FBTweakViewController class]]) {
     FBTweakStore *store = [FBTweakStore sharedInstance];
     FBTweakViewController *viewController = [[FBTweakViewController alloc] initWithStore:store];
     viewController.tweaksDelegate = self;
-    [rootViewController presentViewController:viewController animated:YES completion:NULL];
+    [visibleViewController presentViewController:viewController animated:YES completion:NULL];
   }
 }
 


### PR DESCRIPTION
This fixes FBTweakViewController not being presented if rootViewController has presented another view controller, because its view is not in the window hierarchy. The error I was getting was:

_Warning: Attempt to present <FBTweakViewController: 0x914ffd0> on <UITabBarController: 0x8c7bc70> whose view is not in the window hierarchy!_

It also enables presentation of FBTweakViewController when we are deeper into the hierarchy.
