### PR TITLE
Assigns default max/min values when default value is float 0

### DIFF
--- a/FBTweak/_FBTweakTableViewCell.m
+++ b/FBTweak/_FBTweakTableViewCell.m
@@ -149,12 +149,16 @@ typedef NS_ENUM(NSUInteger, _FBTweakTableViewCellMode) {
     
     if (_tweak.minimumValue != nil) {
       _stepper.minimumValue = [_tweak.minimumValue doubleValue];
+    } else if ([_tweak.defaultValue doubleValue] == 0) {
+      _stepper.minimumValue = -1;
     } else {
       _stepper.minimumValue = [_tweak.defaultValue doubleValue] / 10.0;
     }
     
     if (_tweak.maximumValue != nil) {
       _stepper.maximumValue = [_tweak.maximumValue doubleValue];
+    } else if ([_tweak.defaultValue doubleValue] == 0) {
+      _stepper.maximumValue = 1;
     } else {
       _stepper.maximumValue = [_tweak.defaultValue doubleValue] * 10.0;
     }


### PR DESCRIPTION
Consider the following inline tweak declaration:

```
FBTweakValue(@"Foo", @"Bar", @"Baz", 0.)
```

The program will throw a `NSInvalidArgumentException 'stepValue must be greater than 0'` because the code computes max and min value in factors of the default value, and computes stepValue based on those values.

The workaround is to explicitly declare max and min values, but what if I don't want to do that?  It seems that Tweaks should set some reasonable max and min values _for me_ in this case, at least to prevent the exception.  So, this patch proposes that change.  If the default value is float 0, the max is set to 1 and min to -1.
