### PR TITLE
Assigns max/min values when default value is integer

### DIFF
--- a/FBTweak/_FBTweakTableViewCell.m
+++ b/FBTweak/_FBTweakTableViewCell.m
@@ -138,8 +138,19 @@ typedef NS_ENUM(NSUInteger, _FBTweakTableViewCellMode) {
     _textField.keyboardType = UIKeyboardTypeNumberPad;
     _stepper.hidden = NO;
     _stepper.stepValue = 1.0;
-    _stepper.minimumValue = [_tweak.minimumValue longLongValue];
-    _stepper.maximumValue = [_tweak.maximumValue longLongValue];
+    
+    if (_tweak.minimumValue != nil) {
+      _stepper.minimumValue = [_tweak.minimumValue longLongValue];
+    } else {
+      _stepper.minimumValue = [_tweak.defaultValue longLongValue] - 50;
+    }
+    
+    if (_tweak.maximumValue != nil) {
+      _stepper.maximumValue = [_tweak.maximumValue longLongValue];
+    } else {
+      _stepper.maximumValue = [_tweak.defaultValue longLongValue] + 50;
+    }
+    
   } else if (_mode == _FBTweakTableViewCellModeReal) {
     _switch.hidden = YES;
     _textField.hidden = NO;


### PR DESCRIPTION
In the case of integers, when no max or min is specified, Tweaks disables the stepper.  Perhaps that's the desired behavior, but if not, this patch will assign a default spread of 100 for the max and min given an integer input.
