### PR TITLE
Fix bug where tweak loses integer mode

### DIFF
--- a/FBTweak/_FBTweakTableViewCell.m
+++ b/FBTweak/_FBTweakTableViewCell.m
@@ -260,12 +260,12 @@ typedef NS_ENUM(NSUInteger, _FBTweakTableViewCellMode) {
 
 - (void)_stepperChanged:(UIStepper *)stepper
 {
-    if (_mode == _FBTweakTableViewCellModeInteger) {
-        NSNumber *number = @([@(stepper.value) longLongValue]);
-        [self _updateValue:number primary:NO write:YES];
-    } else {
-        [self _updateValue:@(stepper.value) primary:NO write:YES];
-    }
+  if (_mode == _FBTweakTableViewCellModeInteger) {
+    NSNumber *number = @([@(stepper.value) longLongValue]);
+    [self _updateValue:number primary:NO write:YES];
+  } else {
+    [self _updateValue:@(stepper.value) primary:NO write:YES];
+  }
 }
 
 - (void)_updateValue:(FBTweakValue)value primary:(BOOL)primary write:(BOOL)write


### PR DESCRIPTION
Fix issue with integer value stepper becoming a real value stepper after the first update.
The value type of a UIStepper is double, so when boxing this into an NSNumber,
the mode needs to be considered to ensure the updated tweak remains an integer value.
