### PR TITLE
Give as much space as possible to string-value tweak textfield

### DIFF
--- a/FBTweak/_FBTweakTableViewCell.m
+++ b/FBTweak/_FBTweakTableViewCell.m
@@ -80,9 +80,9 @@ typedef NS_ENUM(NSUInteger, _FBTweakTableViewCellMode) {
     CGRect accessoryFrame = CGRectUnion(stepperFrame, textFrame);
     _accessoryView.bounds = CGRectIntegral(accessoryFrame);
   } else if (_mode == _FBTweakTableViewCellModeString) {
-    CGFloat labelWidth = self.textLabel.intrinsicContentSize.width;
-    CGFloat margin = self.textLabel.frame.origin.x;
-    CGRect textBounds = CGRectMake(0, 0, self.bounds.size.width - margin * 3 - labelWidth, self.bounds.size.height);
+    CGFloat margin = CGRectGetMinX(self.textLabel.frame);
+    CGFloat textFieldWidth = self.bounds.size.width - (margin * 3.0) - [self.textLabel sizeThatFits:CGSizeZero].width;
+    CGRect textBounds = CGRectMake(0, 0, textFieldWidth, self.bounds.size.height);
     _textField.frame = CGRectIntegral(textBounds);
     _accessoryView.bounds = CGRectIntegral(textBounds);
   } else if (_mode == _FBTweakTableViewCellModeAction) {


### PR DESCRIPTION
This fixes a textfield truncation issue I encountered a few times in which string tweaks got truncated when they were more than ~10 characters long. It now gives as much space as possible to the textfield.
