### PR TITLE
Disabling FBTweakShakeWindow appearance in RELEASE

### DIFF
--- a/FBTweak/FBTweakShakeWindow.m
+++ b/FBTweak/FBTweakShakeWindow.m
@@ -41,7 +41,9 @@ static CFTimeInterval _FBTweakShakeWindowMinTimeInterval = 0.4;
 
 - (BOOL)_shouldPresentTweaks
 {
-#if TARGET_IPHONE_SIMULATOR
+#ifndef DEBUG
+    return NO;
+#elif TARGET_IPHONE_SIMULATOR
   return YES;
 #else
   return _shaking && [[UIApplication sharedApplication] applicationState] == UIApplicationStateActive;


### PR DESCRIPTION
Disabling FBTweakShakeWindow appearance in release configuration. 
I think it's better to disable ability to show FBTweakShakeWindow in release configuration because it's easy to forget about it before actually publishing app to App Store
