### PR TITLE
Fixes UIBarButtonItemStyleBordered deprecation.

### DIFF
--- a/FBTweak/_FBTweakCategoryViewController.m
+++ b/FBTweak/_FBTweakCategoryViewController.m
@@ -65,7 +65,7 @@
   self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(_done)];
   
   if ([MFMailComposeViewController canSendMail]) {
-    UIBarButtonItem *exportItem = [[UIBarButtonItem alloc] initWithTitle:@"Export" style:UIBarButtonItemStyleBordered target:self action:@selector(_export)];
+    UIBarButtonItem *exportItem = [[UIBarButtonItem alloc] initWithTitle:@"Export" style:UIBarButtonItemStyleDone target:self action:@selector(_export)];
     UIBarButtonItem *flexibleSpaceItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];
     
     _toolbar.items = @[flexibleSpaceItem, exportItem];


### PR DESCRIPTION
As of iOS 8, UIBarButtonItemStyleBordered is deprecated. I changed that to UIBarButtonItemStyleDone.
