### PR TITLE
Add NSNotification posting when the FBTweakShakeWindow dismisses the FBTweakViewController

### DIFF
--- a/FBTweak.xcodeproj/project.pbxproj
+++ b/FBTweak.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		18EFE52D189F250700DA6A5D /* FBTweakInlineTestsMRR.m in Sources */ = {isa = PBXBuildFile; fileRef = 18EFE52C189F250700DA6A5D /* FBTweakInlineTestsMRR.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		18EFE536189F38D500DA6A5D /* FBTweakEnabled.h in Headers */ = {isa = PBXBuildFile; fileRef = 18EFE535189F38D500DA6A5D /* FBTweakEnabled.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		29E9F17B18E35C9C001EAF7D /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 29E9F17A18E35C9C001EAF7D /* MessageUI.framework */; };
+		AA5EFC4D196FCB6A00653AC7 /* FBTweakConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = AA5EFC4B196FCB6A00653AC7 /* FBTweakConstants.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -88,6 +89,7 @@
 		18EFE52C189F250700DA6A5D /* FBTweakInlineTestsMRR.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBTweakInlineTestsMRR.m; sourceTree = "<group>"; };
 		18EFE535189F38D500DA6A5D /* FBTweakEnabled.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBTweakEnabled.h; sourceTree = "<group>"; };
 		29E9F17A18E35C9C001EAF7D /* MessageUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MessageUI.framework; path = System/Library/Frameworks/MessageUI.framework; sourceTree = SDKROOT; };
+		AA5EFC4B196FCB6A00653AC7 /* FBTweakConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBTweakConstants.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -148,6 +150,7 @@
 			isa = PBXGroup;
 			children = (
 				18EFE535189F38D500DA6A5D /* FBTweakEnabled.h */,
+				AA5EFC4B196FCB6A00653AC7 /* FBTweakConstants.h */,
 				18EFE532189F286000DA6A5D /* Inline */,
 				18EFE4B9189EBC3500DA6A5D /* Model */,
 				18EFE4BE189EBD0800DA6A5D /* UI */,
@@ -243,6 +246,7 @@
 				18EFE4B3189EBAC200DA6A5D /* FBTweakShakeWindow.h in Headers */,
 				18EFE536189F38D500DA6A5D /* FBTweakEnabled.h in Headers */,
 				18EFE4D0189EC70300DA6A5D /* FBTweakInlineInternal.h in Headers */,
+				AA5EFC4D196FCB6A00653AC7 /* FBTweakConstants.h in Headers */,
 				18EFE527189F19B300DA6A5D /* FBTweakCategory.h in Headers */,
 				18EFE4BC189EBC4B00DA6A5D /* FBTweakCollection.h in Headers */,
 				18EFE4DD189EF75800DA6A5D /* _FBTweakTableViewCell.h in Headers */,

--- a/FBTweak/FBTweakConstants.h
+++ b/FBTweak/FBTweakConstants.h
@@ -1,0 +1,9 @@
+//
+//  FBTweakConstants.h
+//  FBTweak
+//
+//  Created by Tudor Munteanu on 11/07/14.
+//  Copyright (c) 2014 Facebook. All rights reserved.
+//
+
+#define FB_TWEAK_DISMISS_NOTIFICATION @"FB_TWEAK_DISMISS_NOTIFICATION"

--- a/FBTweak/FBTweakShakeWindow.m
+++ b/FBTweak/FBTweakShakeWindow.m
@@ -7,6 +7,7 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#import "FBTweakConstants.h"
 #import "FBTweakEnabled.h"
 #import "FBTweakStore.h"
 #import "FBTweakShakeWindow.h"
@@ -21,6 +22,7 @@ static CFTimeInterval _FBTweakShakeWindowMinTimeInterval = 0.4;
 
 - (void)tweakViewControllerPressedDone:(FBTweakViewController *)tweakViewController
 {
+  [[NSNotificationCenter defaultCenter] postNotificationName:FB_TWEAK_DISMISS_NOTIFICATION object:tweakViewController];
   [tweakViewController dismissViewControllerAnimated:YES completion:NULL];
 }
 


### PR DESCRIPTION
Adds a simpler way to know when the FBTweakViewController is dismissed, to update the new values.
