### PR TITLE
Fix for Shake UI displaying in simulator

### DIFF
--- a/FBTweak/FBTweakShakeWindow.m
+++ b/FBTweak/FBTweakShakeWindow.m
@@ -43,12 +43,12 @@ static CFTimeInterval _FBTweakShakeWindowMinTimeInterval = 0.4;
 
 - (BOOL)_shouldPresentTweaks
 {
-#if FB_TWEAK_ENABLED
+#if TARGET_IPHONE_SIMULATOR
+    return YES;
+#elif FB_TWEAK_ENABLED
     return _shaking && [[UIApplication sharedApplication] applicationState] == UIApplicationStateActive;
-#elif TARGET_IPHONE_SIMULATOR
-  return YES;
 #else
-  return NO;
+    return NO;
 #endif
 }
 


### PR DESCRIPTION
Since in the simulator (tested w/iPhone 6 sim) shake motions begin and end at the same time, the UI will never display in the simulator without this change.  
