### PR TITLE
Fixed #55

### DIFF
--- a/FBTweak/_FBTweakCollectionViewController.m
+++ b/FBTweak/_FBTweakCollectionViewController.m
@@ -123,4 +123,10 @@
   return cell;
 }
 
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
+{
+  _FBTweakTableViewCell *cell = (_FBTweakTableViewCell *)[tableView cellForRowAtIndexPath:indexPath];
+  [cell delegateCellSelected];
+}
+
 @end

--- a/FBTweak/_FBTweakTableViewCell.h
+++ b/FBTweak/_FBTweakTableViewCell.h
@@ -26,4 +26,13 @@
 //! @abstract The tweak to show in the cell.
 @property (nonatomic, strong, readwrite) FBTweak *tweak;
 
+/**
+  @abstract Action callback that is called from table views when a cell is selected by user.
+  @discussion Using -setSelected:animated: method to detect when cells are selected isn't reliable,
+  since -setSelected:animated: is called twice unexpectedly on iPad (possibly due to Apple's implementation).
+  It has to be workarounded by using -tableView:didSelectRowAtIndexPath: to detect user selections
+  then message it to cells.
+ */
+- (void)delegateCellSelected;
+
 @end

--- a/FBTweak/_FBTweakTableViewCell.m
+++ b/FBTweak/_FBTweakTableViewCell.m
@@ -225,11 +225,16 @@ typedef NS_ENUM(NSUInteger, _FBTweakTableViewCellMode) {
   if (_mode == _FBTweakTableViewCellModeAction) {
     if (selected) {
       [self setSelected:NO animated:YES];
+    }
+  }
+}
 
-      dispatch_block_t block = _tweak.defaultValue;
-      if (block != NULL) {
-        block();
-      }
+- (void)delegateCellSelected
+{
+  if (_mode == _FBTweakTableViewCellModeAction) {
+    dispatch_block_t block = _tweak.defaultValue;
+    if (block != NULL) {
+      block();
     }
   }
 }


### PR DESCRIPTION
Fixed a issue that actions would be called twice (or more than twice), or possibly cells are not even selected by user. Tested on my devices (iPhone and iPad, both iOS 8.1) and worked fine.

This is VERY ugly workaround imo, but everything else are handled in the cell class rather than in the view controller class, this implementation should keep consistency with it. Any better suggestions?


Any better suggestions?