### PR TITLE
Press done button may not update the last modified tweak data immediately

### DIFF
--- a/FBTweak/FBTweakShakeWindow.m
+++ b/FBTweak/FBTweakShakeWindow.m
@@ -51,6 +51,7 @@ static CFTimeInterval _FBTweakShakeWindowMinTimeInterval = 0.4;
 - (void)tweakViewControllerPressedDone:(FBTweakViewController *)tweakViewController
 {
   [[NSNotificationCenter defaultCenter] postNotificationName:FBTweakShakeViewControllerDidDismissNotification object:tweakViewController];
+  [tweakViewController.view endEditing:YES];
   [tweakViewController dismissViewControllerAnimated:YES completion:NULL];
 }
 


### PR DESCRIPTION
When the textField in `FBTweakTableViewCell` is still the firstResponder, and the press done button is pressed, the last modified tweak data will not be updated immediately. (It will be updated until the dismissViewControllerAnimated animation finished, which I think it's not an ideal opportunity.)