### PR TITLE
Override -initWithCoder: in FBTweakShakeWindow so nib-windows work on device

### DIFF
--- a/FBTweak/FBTweakShakeWindow.m
+++ b/FBTweak/FBTweakShakeWindow.m
@@ -23,13 +23,26 @@ static CFTimeInterval _FBTweakShakeWindowMinTimeInterval = 0.4;
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if ((self = [super initWithFrame:frame])) {
-    // Maintain this state manually using notifications so Tweaks can be used in app extensions, where UIApplication is unavailable.
-    _active = YES;
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_applicationWillResignActiveWithNotification:) name:UIApplicationWillResignActiveNotification object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_applicationDidBecomeActiveWithNotification:) name:UIApplicationDidBecomeActiveNotification object:nil];
+    _FBTweakShakeWindowCommonInit(self);
   }
 
   return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)coder
+{
+  if ((self = [super initWithCoder:coder])) {
+    _FBTweakShakeWindowCommonInit(self);
+  }
+  return self;
+}
+
+static void _FBTweakShakeWindowCommonInit(FBTweakShakeWindow *self)
+{
+  // Maintain this state manually using notifications so Tweaks can be used in app extensions, where UIApplication is unavailable.
+  self->_active = YES;
+  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_applicationWillResignActiveWithNotification:) name:UIApplicationWillResignActiveNotification object:nil];
+  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_applicationDidBecomeActiveWithNotification:) name:UIApplicationDidBecomeActiveNotification object:nil];
 }
 
 - (void)dealloc


### PR DESCRIPTION
This makes changing your window's class in the nib makes tweaks work a-ok on device.

Currently you have to somehow set the `_active` ivar on the window to `YES` (e.g. via KVC) before it'll work, which is non-obvious.

(I realize windows-in-nibs isn't terribly common practice on iOS, but I just ran into it, so I figured why not.)