### PR TITLE
Add NSCoding conformance to FBTweakNumericRange

### DIFF
--- a/FBTweak/FBTweak.h
+++ b/FBTweak/FBTweak.h
@@ -23,7 +23,7 @@ typedef id FBTweakValue;
   @abstract Represents a range of values for a numeric tweak.
   @discussion Use this for the -possibleValues on a tweak.
  */
-@interface FBTweakNumericRange : NSObject
+@interface FBTweakNumericRange : NSObject <NSCoding>
 
 /**
   @abstract Creates a new numeric range.

--- a/FBTweak/FBTweak.m
+++ b/FBTweak/FBTweak.m
@@ -24,6 +24,21 @@
   return self;
 }
 
+- (instancetype)initWithCoder:(NSCoder *)coder
+{
+  FBTweakValue minimumValue = [coder decodeObjectForKey:@"minimumValue"];
+  FBTweakValue maximumValue = [coder decodeObjectForKey:@"maximumValue"];
+  self = [self initWithMinimumValue:minimumValue maximumValue:maximumValue];
+
+  return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder
+{
+  [coder encodeObject:_minimumValue forKey:@"minimumValue"];
+  [coder encodeObject:_maximumValue forKey:@"maximumValue"];
+}
+
 @end
 
 @implementation FBTweak {


### PR DESCRIPTION
This pull request fixes a crash occurring during exporting. It can be tested on the `FBTweakExample` project.