### PR TITLE
Fix a bug with integer tweak showing as float

### DIFF
--- a/FBTweak/_FBTweakTableViewCell.m
+++ b/FBTweak/_FBTweakTableViewCell.m
@@ -121,7 +121,9 @@ typedef NS_ENUM(NSUInteger, _FBTweakTableViewCellMode) {
         strcmp([value objCType], @encode(_Bool)) == 0) {
       mode = _FBTweakTableViewCellModeBoolean;
     } else if (strcmp([value objCType], @encode(NSInteger)) == 0 ||
-               strcmp([value objCType], @encode(NSUInteger)) == 0) {
+               strcmp([value objCType], @encode(NSUInteger)) == 0 ||
+               strcmp([value objCType], @encode(int)) == 0 ||
+               strcmp([value objCType], @encode(long)) == 0) {
       mode = _FBTweakTableViewCellModeInteger;
     } else {
       mode = _FBTweakTableViewCellModeReal;


### PR DESCRIPTION
On the version from `master`, integer mode isn't correctly chosen for a tweak, whose code path isn't
reached during program execution. For example:

```obj-c
FBTweakValue(@"Integer Tweak", @"Int", @"Int", 1, 1, 2);
```

is shown as as floating point number: `1.0`.

I created two examples presenting this issue:
- https://github.com/fastred/Tweaks/tree/integer-cell-mode-example-bad
- https://github.com/fastred/Tweaks/tree/integer-cell-mode-example-good

Please open "Integer Tweak" category in each one to see the difference. You have to perform a clean build when switching between branches.

We should probably also add unit tests for the method that chooses a cell mode. It'd require some refactoring, though. Also, I'm not sure how to properly test the behavior that I've fixed. Any thoughts on that?