### PR TITLE
Emit error when trying to compile for C++ (use of _Generic())

### DIFF
--- a/FBTweak/FBTweakInlineInternal.h
+++ b/FBTweak/FBTweakInlineInternal.h
@@ -103,7 +103,11 @@ extern NSString *_FBTweakIdentifier(fb_tweak_entry *entry);
   return __inline_tweak; \
 })())
 #define _FBTweakInline(category_, collection_, name_, ...) _FBTweakDispatch(_FBTweakInlineWithoutRange, _FBTweakInlineWithRange, _FBTweakInlineWithPossible, __VA_ARGS__)(category_, collection_, name_, __VA_ARGS__)
-  
+
+#ifdef __cplusplus
+#define _FBTweakValueInternal(...) \
+((^{ static_assert(false, "C++ not supported at present. See https://github.com/facebook/Tweaks/issues/84."); nil; })())
+#else
 #define _FBTweakValueInternal(tweak_, category_, collection_, name_, default_) \
 ((^{ \
   /* returns a correctly typed version of the current tweak value */ \
@@ -140,6 +144,7 @@ extern NSString *_FBTweakIdentifier(fb_tweak_entry *entry);
     default: [currentValue UTF8String] \
   ); \
 })())
+#endif
 
 #define _FBTweakValueWithoutRange(category_, collection_, name_, default_) \
 ((^{ \


### PR DESCRIPTION
Resolves https://github.com/facebook/Tweaks/issues/84

It would seem that Tweaks can't compile for C++ due to implementing `_FBTweakValueInternal()` with `_Generic()`. In lieu of creating a C++ compatible implementation, perhaps it would be better to instead provide a clear error, with the suggestion to expose Tweaks values to C++ from ObjC/C methods defined elsewhere?

Please let me know what you think. Thanks!