### PR TITLE
Added the method tweakWillChange: in the FBTweakObserver protocol

### DIFF
--- a/FBTweak/FBTweak.h
+++ b/FBTweak/FBTweak.h
@@ -157,4 +157,12 @@ typedef id FBTweakValue;
  */
 - (void)tweakDidChange:(FBTweak *)tweak;
 
+@optional
+
+/**
+ @abstract Called when a tweak's value will change.
+ @param tweak The tweak which value will change.
+ */
+- (void)tweakWillChange:(FBTweak *)tweak;
+
 @end

--- a/FBTweak/FBTweak.m
+++ b/FBTweak/FBTweak.m
@@ -175,6 +175,13 @@
   }
 
   if (_currentValue != currentValue) {
+      
+    for (id<FBTweakObserver> observer in [_observers setRepresentation]) {
+      if ([observer respondsToSelector:@selector(tweakWillChange:)]) {
+        [observer tweakWillChange:self];
+      }
+    }
+      
     _currentValue = currentValue;
     [[NSUserDefaults standardUserDefaults] setObject:_currentValue forKey:_identifier];
     

--- a/README.md
+++ b/README.md
@@ -123,6 +123,15 @@ Then, you can watch for when the tweak changes:
 }
 ```
 
+Also you have de ability to implement the optional method `tweakWillChange:` in order to handle the previous value of your tweak:
+
+```objective-c
+- (void)tweakWillChange:(FBTweak *)tweak
+{
+  NSLog(@"%@", tweak.currentValue); // Here current value is the previous value of the tweak
+}
+```
+
 To override when tweaks are enabled, you can define the `FB_TWEAK_ENABLED` macro. It's suggested to avoid including them when submitting to the App Store.
 
 ### Using from a Swift Project


### PR DESCRIPTION
Hi guys!

I've added the method tweakWillChange: to the FBTweakObserver in order to track the previous value of a tweak. I did this because one of my tweaks handles the API endpoint, so when someone changes the API endpoint, I force a logout from the app. But if someone, accidentally, picks the same tweak value, I want to know if the previous value of the tweak is different from the current one, so that if it is, I can force a logout.

Thanks and I hope you merge this pull request.

Joel.