### PR TITLE
Revert "Emit error when trying to compile for C++ (use of _Generic())"

### DIFF
--- a/FBTweak/FBTweakInlineInternal.h
+++ b/FBTweak/FBTweakInlineInternal.h
@@ -103,11 +103,7 @@ extern NSString *_FBTweakIdentifier(fb_tweak_entry *entry);
   return __inline_tweak; \
 })())
 #define _FBTweakInline(category_, collection_, name_, ...) _FBTweakDispatch(_FBTweakInlineWithoutRange, _FBTweakInlineWithRange, _FBTweakInlineWithPossible, __VA_ARGS__)(category_, collection_, name_, __VA_ARGS__)
-
-#ifdef __cplusplus
-#define _FBTweakValueInternal(...) \
-((^{ static_assert(false, "C++ not supported at present. See https://github.com/facebook/Tweaks/issues/84."); nil; })())
-#else
+  
 #define _FBTweakValueInternal(tweak_, category_, collection_, name_, default_) \
 ((^{ \
   /* returns a correctly typed version of the current tweak value */ \
@@ -144,7 +140,6 @@ extern NSString *_FBTweakIdentifier(fb_tweak_entry *entry);
     default: [currentValue UTF8String] \
   ); \
 })())
-#endif
 
 #define _FBTweakValueWithoutRange(category_, collection_, name_, default_) \
 ((^{ \


### PR DESCRIPTION
Reverts facebook/Tweaks#88

Well... Most strange, but this *appears* to now be working without issue. It's possible it isn't *always* broken, and it might be better to remove the assert in order to not prevent anyone using the library that might otherwise not experience an issue.

:+1: by @ashoemaker on the original issue. Not sure if this means he'd seen it as well?

Sorry for the confusion.