### PR TITLE
Adds sanity check on NSData when unpacking value from defaults

### DIFF
--- a/FBTweak/FBTweak.m
+++ b/FBTweak/FBTweak.m
@@ -77,7 +77,7 @@
   if ((self = [super init])) {
     _identifier = identifier;
     NSData *archivedValue = [[NSUserDefaults standardUserDefaults] objectForKey:_identifier];
-    _currentValue = (archivedValue == nil ? archivedValue : [NSKeyedUnarchiver unarchiveObjectWithData:archivedValue]);
+    _currentValue = (archivedValue != nil && [archivedValue isKindOfClass:[NSData class]] ? [NSKeyedUnarchiver unarchiveObjectWithData:archivedValue] : archivedValue);
   }
   
   return self;


### PR DESCRIPTION
A crash can occur when updating tweaks when the NSUserDefaults don't hold an NSData value for the identifier.

This fix ensures that all stored values are properly formatted before unpacking them.