### PR TITLE
Fix header search paths while archiving

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: objective-c
 script: 
   - xctool test -project FBTweak.xcodeproj -scheme FBTweak -sdk iphonesimulator8.1 -destination "platform=iOS Simulator,OS=8.1,name=iPhone 6"
-  - xctool archive -workspace FBTweakExample.xcworkspace -scheme FBTweakExample
+  - xctool archive -workspace FBTweakExample.xcworkspace -scheme FBTweakExample CODE_SIGN_IDENTITY="-"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: objective-c
 script: 
   - xctool test -project FBTweak.xcodeproj -scheme FBTweak -sdk iphonesimulator8.1 -destination "platform=iOS Simulator,OS=8.1,name=iPhone 6"
-  - xctool archive -workspace FBTweakExample.xcworkspace -scheme FBTweakExample CODE_SIGNING_REQUIRED=NO
+  - xctool archive -workspace FBTweakExample.xcworkspace -scheme FBTweakExample CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: objective-c
-script: xctool test -project FBTweak.xcodeproj -scheme FBTweak -sdk iphonesimulator8.1 -destination "platform=iOS Simulator,OS=8.1,name=iPhone 6"
-
+script: 
+  - xctool test -project FBTweak.xcodeproj -scheme FBTweak -sdk iphonesimulator8.1 -destination "platform=iOS Simulator,OS=8.1,name=iPhone 6"
+  - xctool archive -workspace FBTweakExample.xcworkspace -scheme FBTweakExample

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: objective-c
 script: 
   - xctool test -project FBTweak.xcodeproj -scheme FBTweak -sdk iphonesimulator8.1 -destination "platform=iOS Simulator,OS=8.1,name=iPhone 6"
-  - xctool archive -workspace FBTweakExample.xcworkspace -scheme FBTweakExample CODE_SIGN_IDENTITY="-"
+  - xctool archive -workspace FBTweakExample.xcworkspace -scheme FBTweakExample CODE_SIGNING_REQUIRED=NO

--- a/FBTweak.xcodeproj/project.pbxproj
+++ b/FBTweak.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		184A94F018D26871005F2774 /* _FBTweakBindObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 184A94EE18D26871005F2774 /* _FBTweakBindObserver.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		184A94F118D26871005F2774 /* _FBTweakBindObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 184A94EF18D26871005F2774 /* _FBTweakBindObserver.m */; };
 		18EFE472189EBA4900DA6A5D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 18EFE471189EBA4900DA6A5D /* Foundation.framework */; };
 		18EFE480189EBA4900DA6A5D /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 18EFE47F189EBA4900DA6A5D /* XCTest.framework */; };
@@ -18,49 +17,37 @@
 		18EFE4A7189EBA9E00DA6A5D /* FBTweakViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 18EFE4A5189EBA9E00DA6A5D /* FBTweakViewController.m */; };
 		18EFE4AB189EBAAD00DA6A5D /* FBTweakInline.m in Sources */ = {isa = PBXBuildFile; fileRef = 18EFE4A9189EBAAD00DA6A5D /* FBTweakInline.m */; };
 		18EFE4AF189EBABA00DA6A5D /* FBTweakShakeWindow.m in Sources */ = {isa = PBXBuildFile; fileRef = 18EFE4AD189EBABA00DA6A5D /* FBTweakShakeWindow.m */; };
-		18EFE4B2189EBAC200DA6A5D /* FBTweakInline.h in Headers */ = {isa = PBXBuildFile; fileRef = 18EFE4A8189EBAAD00DA6A5D /* FBTweakInline.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		18EFE4B3189EBAC200DA6A5D /* FBTweakShakeWindow.h in Headers */ = {isa = PBXBuildFile; fileRef = 18EFE4AC189EBABA00DA6A5D /* FBTweakShakeWindow.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		18EFE4B4189EBAC200DA6A5D /* FBTweakViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 18EFE4A4189EBA9E00DA6A5D /* FBTweakViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		18EFE4B7189EBC3100DA6A5D /* FBTweak.h in Headers */ = {isa = PBXBuildFile; fileRef = 18EFE4B5189EBC3100DA6A5D /* FBTweak.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		18EFE4B8189EBC3100DA6A5D /* FBTweak.m in Sources */ = {isa = PBXBuildFile; fileRef = 18EFE4B6189EBC3100DA6A5D /* FBTweak.m */; };
-		18EFE4BC189EBC4B00DA6A5D /* FBTweakCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = 18EFE4BA189EBC4B00DA6A5D /* FBTweakCollection.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		18EFE4BD189EBC4B00DA6A5D /* FBTweakCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = 18EFE4BB189EBC4B00DA6A5D /* FBTweakCollection.m */; };
-		18EFE4C1189EBEAD00DA6A5D /* FBTweakStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 18EFE4BF189EBEAD00DA6A5D /* FBTweakStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		18EFE4C2189EBEAD00DA6A5D /* FBTweakStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 18EFE4C0189EBEAD00DA6A5D /* FBTweakStore.m */; };
-		18EFE4D0189EC70300DA6A5D /* FBTweakInlineInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 18EFE4CF189EC70300DA6A5D /* FBTweakInlineInternal.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		18EFE4D2189ECF2000DA6A5D /* FBTweakInlineTestsARC.m in Sources */ = {isa = PBXBuildFile; fileRef = 18EFE4D1189ECF2000DA6A5D /* FBTweakInlineTestsARC.m */; };
-		18EFE4D5189EEBC500DA6A5D /* _FBTweakCategoryViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 18EFE4D3189EEBC500DA6A5D /* _FBTweakCategoryViewController.h */; };
 		18EFE4D6189EEBC500DA6A5D /* _FBTweakCategoryViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 18EFE4D4189EEBC500DA6A5D /* _FBTweakCategoryViewController.m */; };
-		18EFE4D9189EEED800DA6A5D /* _FBTweakCollectionViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 18EFE4D7189EEED800DA6A5D /* _FBTweakCollectionViewController.h */; };
 		18EFE4DA189EEED800DA6A5D /* _FBTweakCollectionViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 18EFE4D8189EEED800DA6A5D /* _FBTweakCollectionViewController.m */; };
-		18EFE4DD189EF75800DA6A5D /* _FBTweakTableViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 18EFE4DB189EF75800DA6A5D /* _FBTweakTableViewCell.h */; };
 		18EFE4DE189EF75800DA6A5D /* _FBTweakTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 18EFE4DC189EF75800DA6A5D /* _FBTweakTableViewCell.m */; };
-		18EFE527189F19B300DA6A5D /* FBTweakCategory.h in Headers */ = {isa = PBXBuildFile; fileRef = 18EFE525189F19B300DA6A5D /* FBTweakCategory.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		18EFE528189F19B300DA6A5D /* FBTweakCategory.m in Sources */ = {isa = PBXBuildFile; fileRef = 18EFE526189F19B300DA6A5D /* FBTweakCategory.m */; };
 		18EFE52D189F250700DA6A5D /* FBTweakInlineTestsMRR.m in Sources */ = {isa = PBXBuildFile; fileRef = 18EFE52C189F250700DA6A5D /* FBTweakInlineTestsMRR.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		18EFE536189F38D500DA6A5D /* FBTweakEnabled.h in Headers */ = {isa = PBXBuildFile; fileRef = 18EFE535189F38D500DA6A5D /* FBTweakEnabled.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		29E9F17B18E35C9C001EAF7D /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 29E9F17A18E35C9C001EAF7D /* MessageUI.framework */; };
-		5BACB31E1A12813C00C4F79D /* _FBTweakArrayViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 5BACB31C1A12813C00C4F79D /* _FBTweakArrayViewController.h */; };
+		4F930D6C1C4C73F8007DC0E1 /* FBTweakEnabled.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 18EFE535189F38D500DA6A5D /* FBTweakEnabled.h */; };
+		4F930D6D1C4C7406007DC0E1 /* FBTweakInlineInternal.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 18EFE4CF189EC70300DA6A5D /* FBTweakInlineInternal.h */; };
+		4F930D6E1C4C740F007DC0E1 /* FBTweakInline.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 18EFE4A8189EBAAD00DA6A5D /* FBTweakInline.h */; };
+		4F930D6F1C4C7417007DC0E1 /* _FBTweakBindObserver.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 184A94EE18D26871005F2774 /* _FBTweakBindObserver.h */; };
+		4F930D701C4C742A007DC0E1 /* FBTweak.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 18EFE4B5189EBC3100DA6A5D /* FBTweak.h */; };
+		4F930D711C4C742A007DC0E1 /* FBTweakCollection.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 18EFE4BA189EBC4B00DA6A5D /* FBTweakCollection.h */; };
+		4F930D721C4C742A007DC0E1 /* FBTweakCategory.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 18EFE525189F19B300DA6A5D /* FBTweakCategory.h */; };
+		4F930D731C4C742A007DC0E1 /* FBTweakStore.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 18EFE4BF189EBEAD00DA6A5D /* FBTweakStore.h */; };
+		4F930D741C4C743D007DC0E1 /* FBTweakShakeWindow.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 18EFE4AC189EBABA00DA6A5D /* FBTweakShakeWindow.h */; };
+		4F930D751C4C743D007DC0E1 /* FBTweakViewController.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 18EFE4A4189EBA9E00DA6A5D /* FBTweakViewController.h */; };
+		4F930D761C4C7453007DC0E1 /* _FBColorUtils.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 5E1F48E91901E4D500D7C4A2 /* _FBColorUtils.h */; };
 		5BACB31F1A12813C00C4F79D /* _FBTweakArrayViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BACB31D1A12813C00C4F79D /* _FBTweakArrayViewController.m */; };
-		5BE25A521A0AA9D500C97C3E /* _FBTweakDictionaryViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 5BE25A501A0AA9D500C97C3E /* _FBTweakDictionaryViewController.h */; };
 		5BE25A531A0AA9D500C97C3E /* _FBTweakDictionaryViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BE25A511A0AA9D500C97C3E /* _FBTweakDictionaryViewController.m */; };
-		5E1708C91905B89800402135 /* _FBSliderView.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E1708C31905B89800402135 /* _FBSliderView.h */; };
 		5E1708CA1905B89800402135 /* _FBSliderView.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E1708C41905B89800402135 /* _FBSliderView.m */; };
-		5E1708DD190B147000402135 /* _FBKeyboardManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E1708DB190B147000402135 /* _FBKeyboardManager.h */; };
 		5E1708DE190B147000402135 /* _FBKeyboardManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E1708DC190B147000402135 /* _FBKeyboardManager.m */; };
-		5E1F48EB1901E4D500D7C4A2 /* _FBColorUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E1F48E91901E4D500D7C4A2 /* _FBColorUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5E1F48EC1901E4D500D7C4A2 /* _FBColorUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E1F48EA1901E4D500D7C4A2 /* _FBColorUtils.m */; };
 		5E1F48ED1901E80800D7C4A2 /* _FBColorUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E1F48EA1901E4D500D7C4A2 /* _FBColorUtils.m */; };
-		5E66FDCD1B80C309007464F3 /* _FBColorComponentCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E66FDCB1B80C309007464F3 /* _FBColorComponentCell.h */; };
 		5E66FDCE1B80C309007464F3 /* _FBColorComponentCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E66FDCC1B80C309007464F3 /* _FBColorComponentCell.m */; };
-		5E66FDD21B80E4C1007464F3 /* _FBTweakColorViewControllerRGBDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E66FDD01B80E4C1007464F3 /* _FBTweakColorViewControllerRGBDataSource.h */; };
 		5E66FDD31B80E4C1007464F3 /* _FBTweakColorViewControllerRGBDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E66FDD11B80E4C1007464F3 /* _FBTweakColorViewControllerRGBDataSource.m */; };
-		5E66FDD51B80EB6D007464F3 /* _FBTweakColorViewControllerDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E66FDD41B80EB6D007464F3 /* _FBTweakColorViewControllerDataSource.h */; };
-		5E66FDD81B80ECDA007464F3 /* _FBTweakColorViewControllerHSBDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E66FDD61B80ECDA007464F3 /* _FBTweakColorViewControllerHSBDataSource.h */; };
 		5E66FDD91B80ECDA007464F3 /* _FBTweakColorViewControllerHSBDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E66FDD71B80ECDA007464F3 /* _FBTweakColorViewControllerHSBDataSource.m */; };
-		5E66FDDC1B80FA78007464F3 /* _FBColorWheelCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E66FDDA1B80FA78007464F3 /* _FBColorWheelCell.h */; };
 		5E66FDDD1B80FA78007464F3 /* _FBColorWheelCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E66FDDB1B80FA78007464F3 /* _FBColorWheelCell.m */; };
-		5EA9A2E91911968D0071AB23 /* _FBTweakColorViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 5EA9A2E71911968D0071AB23 /* _FBTweakColorViewController.h */; };
 		5EA9A2EA1911968D0071AB23 /* _FBTweakColorViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5EA9A2E81911968D0071AB23 /* _FBTweakColorViewController.m */; };
 		5EB0EA4018F5EFF3009481A6 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5EB0EA3F18F5EFF3009481A6 /* CoreGraphics.framework */; };
 /* End PBXBuildFile section */
@@ -74,6 +61,30 @@
 			remoteInfo = FBTweak;
 		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		4F930D6B1C4C7389007DC0E1 /* Copy Headers */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+				4F930D761C4C7453007DC0E1 /* _FBColorUtils.h in Copy Headers */,
+				4F930D6C1C4C73F8007DC0E1 /* FBTweakEnabled.h in Copy Headers */,
+				4F930D6F1C4C7417007DC0E1 /* _FBTweakBindObserver.h in Copy Headers */,
+				4F930D6D1C4C7406007DC0E1 /* FBTweakInlineInternal.h in Copy Headers */,
+				4F930D6E1C4C740F007DC0E1 /* FBTweakInline.h in Copy Headers */,
+				4F930D701C4C742A007DC0E1 /* FBTweak.h in Copy Headers */,
+				4F930D711C4C742A007DC0E1 /* FBTweakCollection.h in Copy Headers */,
+				4F930D721C4C742A007DC0E1 /* FBTweakCategory.h in Copy Headers */,
+				4F930D731C4C742A007DC0E1 /* FBTweakStore.h in Copy Headers */,
+				4F930D741C4C743D007DC0E1 /* FBTweakShakeWindow.h in Copy Headers */,
+				4F930D751C4C743D007DC0E1 /* FBTweakViewController.h in Copy Headers */,
+			);
+			name = "Copy Headers";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		184A94EE18D26871005F2774 /* _FBTweakBindObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _FBTweakBindObserver.h; sourceTree = "<group>"; };
@@ -305,40 +316,6 @@
 		};
 /* End PBXGroup section */
 
-/* Begin PBXHeadersBuildPhase section */
-		18EFE497189EBA5A00DA6A5D /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				18EFE4B7189EBC3100DA6A5D /* FBTweak.h in Headers */,
-				5E1708DD190B147000402135 /* _FBKeyboardManager.h in Headers */,
-				5E66FDD81B80ECDA007464F3 /* _FBTweakColorViewControllerHSBDataSource.h in Headers */,
-				18EFE4D5189EEBC500DA6A5D /* _FBTweakCategoryViewController.h in Headers */,
-				18EFE4D9189EEED800DA6A5D /* _FBTweakCollectionViewController.h in Headers */,
-				18EFE4B4189EBAC200DA6A5D /* FBTweakViewController.h in Headers */,
-				18EFE4C1189EBEAD00DA6A5D /* FBTweakStore.h in Headers */,
-				5E66FDD51B80EB6D007464F3 /* _FBTweakColorViewControllerDataSource.h in Headers */,
-				18EFE4B2189EBAC200DA6A5D /* FBTweakInline.h in Headers */,
-				5EA9A2E91911968D0071AB23 /* _FBTweakColorViewController.h in Headers */,
-				18EFE4B3189EBAC200DA6A5D /* FBTweakShakeWindow.h in Headers */,
-				5E1F48EB1901E4D500D7C4A2 /* _FBColorUtils.h in Headers */,
-				18EFE536189F38D500DA6A5D /* FBTweakEnabled.h in Headers */,
-				5E66FDCD1B80C309007464F3 /* _FBColorComponentCell.h in Headers */,
-				18EFE4D0189EC70300DA6A5D /* FBTweakInlineInternal.h in Headers */,
-				18EFE527189F19B300DA6A5D /* FBTweakCategory.h in Headers */,
-				18EFE4BC189EBC4B00DA6A5D /* FBTweakCollection.h in Headers */,
-				5BE25A521A0AA9D500C97C3E /* _FBTweakDictionaryViewController.h in Headers */,
-				18EFE4DD189EF75800DA6A5D /* _FBTweakTableViewCell.h in Headers */,
-				184A94F018D26871005F2774 /* _FBTweakBindObserver.h in Headers */,
-				5E66FDDC1B80FA78007464F3 /* _FBColorWheelCell.h in Headers */,
-				5E1708C91905B89800402135 /* _FBSliderView.h in Headers */,
-				5E66FDD21B80E4C1007464F3 /* _FBTweakColorViewControllerRGBDataSource.h in Headers */,
-				5BACB31E1A12813C00C4F79D /* _FBTweakArrayViewController.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXHeadersBuildPhase section */
-
 /* Begin PBXNativeTarget section */
 		18EFE46D189EBA4900DA6A5D /* FBTweak */ = {
 			isa = PBXNativeTarget;
@@ -346,7 +323,7 @@
 			buildPhases = (
 				18EFE46A189EBA4900DA6A5D /* Sources */,
 				18EFE46B189EBA4900DA6A5D /* Frameworks */,
-				18EFE497189EBA5A00DA6A5D /* Headers */,
+				4F930D6B1C4C7389007DC0E1 /* Copy Headers */,
 			);
 			buildRules = (
 			);

--- a/FBTweakExample.xcodeproj/project.pbxproj
+++ b/FBTweakExample.xcodeproj/project.pbxproj
@@ -221,7 +221,6 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"$(SYMROOT)/Headers",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				ONLY_ACTIVE_ARCH = YES;
@@ -259,7 +258,6 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"$(SYMROOT)/Headers",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				SDKROOT = iphoneos;

--- a/FBTweakExample.xcodeproj/xcshareddata/xcschemes/FBTweakExample.xcscheme
+++ b/FBTweakExample.xcodeproj/xcshareddata/xcschemes/FBTweakExample.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "18EFE4E7189F02F800DA6A5D"
+               BuildableName = "FBTweakExample.app"
+               BlueprintName = "FBTweakExample"
+               ReferencedContainer = "container:FBTweakExample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "18EFE4E7189F02F800DA6A5D"
+            BuildableName = "FBTweakExample.app"
+            BlueprintName = "FBTweakExample"
+            ReferencedContainer = "container:FBTweakExample.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "18EFE4E7189F02F800DA6A5D"
+            BuildableName = "FBTweakExample.app"
+            BlueprintName = "FBTweakExample"
+            ReferencedContainer = "container:FBTweakExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "18EFE4E7189F02F800DA6A5D"
+            BuildableName = "FBTweakExample.app"
+            BlueprintName = "FBTweakExample"
+            ReferencedContainer = "container:FBTweakExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
There's [a portion of Apple's "Using Static Libraries in iOS"](https://developer.apple.com/library/ios/technotes/iOSStaticLibraries/Articles/creating.html#//apple_ref/doc/uid/TP40012554-CH2-SW4) guide that describes this problem with the "Headers" build phase when using static libraries (emphasis added):

> Your library will have one or more header files that clients of that library need to import. To configure which headers are exported to clients, select your library project to open the project editor, select the library target to open the target editor, and select the build phases tab. If your library target has a “Copy Headers” build phase, you should delete it; **copy headers build phases do not work correctly with static library targets when performing the “Archive” action in Xcode.**

When trying to integrate Tweaks into our workspace, we found the same issue: archiving our app was broken.

We've updated FBTweak.xcodeproj to use a custom "Copy Files" build phase that places the public headers into `include/FBTweak/`, relative to the built products directory. This location is automatically added to the header search paths by Xcode, and thus it is no longer necessary to add `$(SYMROOT)/Headers` to the header search paths when building Tweaks from a workspace.

To test this, we've updated `.travis.yml` to perform an archive action in addition to running the tests.