### PR TITLE
added ability to toggle FBTweakShakeWindow's ability to shake

### DIFF
--- a/FBTweak/FBTweakShakeWindow.h
+++ b/FBTweak/FBTweakShakeWindow.h
@@ -17,6 +17,9 @@
  */
 @interface FBTweakShakeWindow : UIWindow <FBTweakViewControllerDelegate>
 
+/**
+ @abstract Toggles FBTweakShakeWindow's ability to respond to shake gestures. Defaults to YES
+ */
 @property (nonatomic) BOOL shakeEnabled;
 
 @end

--- a/FBTweak/FBTweakShakeWindow.h
+++ b/FBTweak/FBTweakShakeWindow.h
@@ -17,4 +17,6 @@
  */
 @interface FBTweakShakeWindow : UIWindow <FBTweakViewControllerDelegate>
 
+@property (nonatomic) BOOL shakeEnabled;
+
 @end

--- a/FBTweak/FBTweakShakeWindow.m
+++ b/FBTweak/FBTweakShakeWindow.m
@@ -42,6 +42,7 @@ static void _FBTweakShakeWindowCommonInit(FBTweakShakeWindow *self)
 {
   // Maintain this state manually using notifications so Tweaks can be used in app extensions, where UIApplication is unavailable.
   self->_active = YES;
+  self->_shakeEnabled = YES;
   [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_applicationWillResignActiveWithNotification:) name:UIApplicationWillResignActiveNotification object:nil];
   [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_applicationDidBecomeActiveWithNotification:) name:UIApplicationDidBecomeActiveNotification object:nil];
 }
@@ -90,7 +91,7 @@ static void _FBTweakShakeWindowCommonInit(FBTweakShakeWindow *self)
 #if TARGET_IPHONE_SIMULATOR && FB_TWEAK_ENABLED
   return YES;
 #elif FB_TWEAK_ENABLED
-  return _shaking && _active;
+  return _shakeEnabled && _shaking && _active;
 #else
   return NO;
 #endif


### PR DESCRIPTION
I need the ability to toggle FBTweakShakeWindow at runtime (even in production builds), so I've added a boolean property for enabling/disabling the shake functionality of FBTweakShakeWindow. 