### PR TITLE
Fix FBTweakActions being called multiple times or on appearance.

### DIFF
--- a/FBTweak/_FBTweakCollectionViewController.m
+++ b/FBTweak/_FBTweakCollectionViewController.m
@@ -132,6 +132,12 @@
   } else if ([tweak.defaultValue isKindOfClass:[UIColor class]]) {
     _FBTweakColorViewController *vc = [[_FBTweakColorViewController alloc] initWithTweak:tweak];
     [self.navigationController pushViewController:vc animated:YES];
+  } else if (tweak.isAction) {
+    dispatch_block_t block = tweak.defaultValue;
+    if (block != NULL) {
+        block();
+    }
+    [tableView deselectRowAtIndexPath:indexPath animated:YES];
   }
 }
 

--- a/FBTweak/_FBTweakTableViewCell.m
+++ b/FBTweak/_FBTweakTableViewCell.m
@@ -265,22 +265,6 @@ typedef NS_ENUM(NSUInteger, _FBTweakTableViewCellMode) {
 
 #pragma mark - Actions
 
-- (void)setSelected:(BOOL)selected animated:(BOOL)animated
-{
-  [super setSelected:selected animated:animated];
-
-  if (_mode == _FBTweakTableViewCellModeAction) {
-    if (selected) {
-      [self setSelected:NO animated:YES];
-
-      dispatch_block_t block = _tweak.defaultValue;
-      if (block != NULL) {
-        block();
-      }
-    }
-  }
-}
-
 - (void)_switchChanged:(UISwitch *)switch_
 {
   [self _updateValue:@(_switch.on) primary:NO write:YES];


### PR DESCRIPTION
Moved `FBTweakAction` block execution from `_FBTweakTableViewCell`'s `setSelected:` to `_FBTweakCollectionViewController`'s `didSelectRowAtIndexPath:`. 

`setSelected:` is a poor choice as it's intended for UI updates, and `UITableView` calls `setSelected:` multiple times and when the cell is being reused.  

This fixes #55 and #83 .