### PR TITLE
Add an example for showing/dismissing the FBTweakViewController manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Actions are useful for things like launching debug UIs, checking for updates, or
 ### Tweaks UI
 To configure your tweaks, you need a way to show the configuration UI. There's two options for that:
 
- - Traditionally, tweaks is activated by shaking your phone. To use that, just replace your root `UIWindow` with a `FBTweakShakeWindow`. If you're using Storyboards, you can override `-window` on your app delegate:
+ - Traditionally, tweaks is activated by shaking your phone. To use that, just replace your root `UIx` with a `FBTweakShakeWindow`. If you're using Storyboards, you can override `-window` on your app delegate:
 
 ```objective-c
 - (UIWindow *)window
@@ -95,7 +95,8 @@ To configure your tweaks, you need a way to show the configuration UI. There's t
  - (void) showTweaks {
     FBTweakViewController *tweakVC = [[FBTweakViewController alloc] initWithStore:[FBTweakStore sharedInstance]];
     tweakVC.tweaksDelegate = self;
-    [[[[UIApplication sharedApplication] keyWindow] rootViewController] presentViewController:tweakVC animated:YES completion:nil];
+    // Assuming this is in the app delegate
+    [self.window.rootViewController presentViewController:tweakVC animated:YES completion:nil];
 }
 
 - (void) tweakViewControllerPressedDone:(FBTweakViewController *)tweakViewController {

--- a/README.md
+++ b/README.md
@@ -91,7 +91,18 @@ To configure your tweaks, you need a way to show the configuration UI. There's t
 ```
 
  - You can present a `FBTweakViewController` from anywhere in your app. Be sure to restrict the activation UI to debug builds!
- 
+ ```objective-c
+ - (void) showTweaks {
+    FBTweakViewController *tweakVC = [[FBTweakViewController alloc] initWithStore:[FBTweakStore sharedInstance]];
+    tweakVC.tweaksDelegate = self;
+    [[[[UIApplication sharedApplication] keyWindow] rootViewController] presentViewController:tweakVC animated:YES completion:nil];
+}
+
+- (void) tweakViewControllerPressedDone:(FBTweakViewController *)tweakViewController {
+    [tweakViewController dismissViewControllerAnimated:YES completion:NULL];
+}
+```
+
 #### Tweaks UI Dismiss Notification
 
 Alternatively, when the Tweaks UI is dismissed, you can register your notification center to listen to `FBTweakShakeViewControllerDidDismissNotification`, which can be used after importing `FBTweakViewController.h` 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Actions are useful for things like launching debug UIs, checking for updates, or
 ### Tweaks UI
 To configure your tweaks, you need a way to show the configuration UI. There's two options for that:
 
- - Traditionally, tweaks is activated by shaking your phone. To use that, just replace your root `UIx` with a `FBTweakShakeWindow`. If you're using Storyboards, you can override `-window` on your app delegate:
+ - Traditionally, tweaks is activated by shaking your phone. To use that, just replace your root `UIWindow` with a `FBTweakShakeWindow`. If you're using Storyboards, you can override `-window` on your app delegate:
 
 ```objective-c
 - (UIWindow *)window


### PR DESCRIPTION
Adds this missing example to the README.
(I was inspired to add this after a lot of confusion setting the `delegate` instead of `tweaksDelegate`!)


>  - You can present a `FBTweakViewController` from anywhere in your app. Be sure to restrict the activation UI to debug builds!
>  ```objective-c
>  - (void) showTweaks {
>     FBTweakViewController *tweakVC = [[FBTweakViewController alloc] initWithStore:[FBTweakStore sharedInstance]];
>     tweakVC.tweaksDelegate = self;
>     [[[[UIApplication sharedApplication] keyWindow] rootViewController] presentViewController:tweakVC animated:YES completion:nil];
> }
> 
> - (void) tweakViewControllerPressedDone:(FBTweakViewController *)tweakViewController {
>     [tweakViewController dismissViewControllerAnimated:YES completion:NULL];
> }