### PR TITLE
Allowed shake enablement for simulator too.

### DIFF
--- a/FBTweak/FBTweakShakeWindow.m
+++ b/FBTweak/FBTweakShakeWindow.m
@@ -89,7 +89,7 @@ static void _FBTweakShakeWindowCommonInit(FBTweakShakeWindow *self)
 - (BOOL)_shouldPresentTweaks
 {
 #if TARGET_IPHONE_SIMULATOR && FB_TWEAK_ENABLED
-  return YES;
+  return _shakeEnabled;
 #elif FB_TWEAK_ENABLED
   return _shakeEnabled && _shaking && _active;
 #else


### PR DESCRIPTION
Allow the shake to be disabled in the simulator too.

This is useful especially if you want to show the React Native Developer menu in the simulator with a shake gesture while also using Tweaks.

_shakeEnabled is already defaulted to YES.