### PR TITLE
Support dark mode

### DIFF
--- a/FBTweak/_FBTweakTableViewCell.m
+++ b/FBTweak/_FBTweakTableViewCell.m
@@ -62,7 +62,11 @@ typedef NS_ENUM(NSUInteger, _FBTweakTableViewCellMode) {
     [_stepper addTarget:self action:@selector(_stepperChanged:) forControlEvents:UIControlEventValueChanged];
     [_accessoryView addSubview:_stepper];
     
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
+    self.detailTextLabel.textColor = [UIColor labelColor];
+#else
     self.detailTextLabel.textColor = [UIColor blackColor];
+#endif
   }
 
   return self;


### PR DESCRIPTION
The detail labels are hard to read in dark-mode.

![image](https://user-images.githubusercontent.com/30267516/84028531-cb51bf00-a988-11ea-9195-a4fc4087a566.png)

This changes it to use [`labelColor`](https://developer.apple.com/documentation/uikit/uicolor/3173131-labelcolor) in iOS 13 which is white in dark-mode.