### PR TITLE
Set autocapitalization based on the first letter of default value

### DIFF
--- a/FBTweak/_FBTweakTableViewCell.m
+++ b/FBTweak/_FBTweakTableViewCell.m
@@ -314,6 +314,7 @@ typedef NS_ENUM(NSUInteger, _FBTweakTableViewCellMode) {
   } else if (_mode == _FBTweakTableViewCellModeString) {
     if (primary) {
       _textField.text = value;
+      [self _updateAutocapitalizationType];
     }
   } else if (_mode == _FBTweakTableViewCellModeInteger) {
     if (primary) {
@@ -345,6 +346,20 @@ typedef NS_ENUM(NSUInteger, _FBTweakTableViewCellMode) {
   } else if (_mode == _FBTweakTableViewCellModeColor) {
     [self.imageView setImage:_FBCreateColorCellsThumbnail(value, CGSizeMake(30, 30))];
   }
+}
+
+- (void)_updateAutocapitalizationType
+{
+    unichar firstLetter = _textField.text.length > 0
+                                ? [_textField.text characterAtIndex:0]
+                                : 0;
+    BOOL isUppercase = [[NSCharacterSet lowercaseLetterCharacterSet] characterIsMember:firstLetter];
+    if (isUppercase) {
+        _textField.autocapitalizationType = UITextAutocapitalizationTypeNone;
+        return;
+    }
+
+    _textField.autocapitalizationType = UITextAutocapitalizationTypeSentences;
 }
 
 @end


### PR DESCRIPTION
Currently all text fields have `autocapitalizationType` set to default which is `UITextAutocapitalizationTypeSentences`. It's a bit annoying if someone wants to have first letter lowercase. One has to type something like 'Vvalue' and remove 'V'. 
The idea is to set `autocapitalizationType` based on the first letter of the value. If it's lowercase then we set `UITextAutocapitalizationTypeNone`, otherwise we keep current behaviour - `UITextAutocapitalizationTypeSentences`.

| BEFORE        | AFTER           | 
| ------------- |:-------------:| 
| ![before](https://user-images.githubusercontent.com/6144246/96141754-9c80c200-0f01-11eb-86d9-a85a074cfa71.gif)      | ![after](https://user-images.githubusercontent.com/6144246/96141769-9f7bb280-0f01-11eb-9e96-218b4d7adf51.gif) | 



